### PR TITLE
fix the jsdoc for @begin/data.page function

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -3,9 +3,9 @@ let get = require('./get')
 /**
  * paginate a table
  *
- * @param {object} params
- * @param {string} table
- * @param {string} limit
+ * @param {Object} props
+ * @param {string} props.table
+ * @param {number} props.limit
  * @returns {asyncIterable}
  */
 module.exports = function page (props) {


### PR DESCRIPTION
The previous JSDoc comment was referencing three different parameters, none of which existed.
This commit updates the comment to reference the single parameter to the function: `props`, and to then document the properties of the `props` parameter.
I noticed that the type for `limit` was also incorrect, from digging into the codebase I believe it is meant to be documented as being a number.

I followed the documentation for [documenting an object parameter with JSDoc](https://jsdoc.app/tags-param.html#parameters-with-properties)

P.S. Begin is excellent! I am really enjoying using it 😄 