### PR TITLE
Allow using with ES6 import

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@begin/data",
   "version": "2.0.1",
   "description": "Begin Data is a durable and fast key/value document store built on top of DynamoDB",
-  "main": "src/index.js",
+  "main": "index.js",
   "scripts": {
     "lint": "eslint src --ignore-pattern node_modules --fix",
     "test": "npm run lint && tape test/*-test.js | tap-spec",


### PR DESCRIPTION
When trying to use `@begin/data` with ES6 `import from` syntax it would fail with the error `Failed to resolve entry for package "@begin/data". The package may have incorrect main/module/exports specified in its package.json`. This fixes that issue.