### PR TITLE
Fix invalid 'main' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@begin/data",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Begin Data is a durable and fast key/value document store built on top of DynamoDB",
-  "main": "src/index.js",
+  "main": "index.js",
   "scripts": {
     "lint": "eslint --fix .",
     "test": "npm run lint && tape test/*-test.js | tap-spec",


### PR DESCRIPTION
Package.json main field pointed to src/index.js, but index.js is in the root directory.